### PR TITLE
Add wrap-predicates function

### DIFF
--- a/src/clj_http_ssrf/core.clj
+++ b/src/clj_http_ssrf/core.clj
@@ -32,3 +32,38 @@
           (and hosts (some #(ip/network-contains? %1 host-address) hosts))
           (make-response status headers body)
           :else (client req))))))
+
+(defn wrap-predicates
+  "Accepts a predicate each for requested scheme, url, port and host.
+
+  If any of the predicates return something falsey,
+  clj-http.client/get will return with the specified :status, :headers and :body.
+
+  :status defaults to 403,
+  :headers defaults to {}
+  :body defaults to \"\"
+
+  Returns a map of status code, header and body (as client would return)"
+  [& {:keys [url-pred port-pred host-pred scheme-pred
+             status headers body]
+      :or {status 403 headers {} body ""}}]
+  (fn [client]
+    (fn [req]
+      (let [url (:url req)
+            parsed-url (client/parse-url url)
+            scheme (:scheme parsed-url)
+            port (:server-port parsed-url)
+            server-name (:server-name parsed-url)
+            host (.getHostAddress (InetAddress/getByName server-name))]
+        (cond
+          (and scheme-pred (not (scheme-pred scheme)))
+          (make-response status headers body)
+          (and url-pred (not (url-pred url)))
+          (make-response status headers body)
+          (and host-pred (not (host-pred host)))
+          (make-response status headers body)
+          ;; Because if the port is not specified in the url, like "http://www.google.com",
+          ;;   port is parsed as nil
+          (and port-pred port (not (port-pred port)))
+          (make-response status headers body)
+          :else (client req))))))

--- a/test/clj_http_ssrf/core_test.clj
+++ b/test/clj_http_ssrf/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [clj-http.client :as client]
             [clj-http-ssrf.core :refer :all]
-            [clj-http-ssrf.reserved :as r]))
+            [clj-http-ssrf.reserved :as r]
+            [inet.data.ip :as ip]))
 
 (def successful-results
   {:status 999 :headers {"Successful" "true"} :body "Success"})
@@ -62,8 +63,83 @@
                                  :hosts [(get-in r/reserved-ip-data [:private :local-a])])
                                 "http://192.168.1.1/index.html")))))
 
+(deftest url-pred-test
+  (testing "url-pred test"
+    (is (= default-results (get-with-middleware
+                            (wrap-predicates :url-pred
+                                             (fn [url] (not (re-find #"internal" url))))
+                            "http://database.internal.com")))
+    (is (= successful-results
+           (get-with-middleware (wrap-predicates :url-pred
+                                                 (fn [url] (re-find #"\.com$" url)))
+                                "http://yahoo.com")))))
+
+(defn safe-scheme?
+  [scheme]
+  (#{:https :http} scheme))
+
+(deftest scheme-pred-test
+  (testing "scheme-pred test"
+    (is (= successful-results (get-with-middleware
+                               (wrap-predicates :scheme-pred safe-scheme?)
+                               "http://yahoo.com")))
+    (is (= successful-results (get-with-middleware
+                               (wrap-predicates :scheme-pred safe-scheme?)
+                               "https://yahoo.com")))
+    (is (= default-results (get-with-middleware
+                            (wrap-predicates :scheme-pred safe-scheme?)
+                            "ftp://ftp.com")))))
+
+(defn safe-host?
+  [host]
+  (not (some #(ip/network-contains? % host) (r/reserved-ip-ranges))))
+
+(deftest host-pred-test
+  (testing "host-pred test"
+    (is (= successful-results
+           (get-with-middleware
+            (wrap-predicates :host-pred safe-host?)
+            "http://8.8.8.8")))
+    (is (= default-results
+           (get-with-middleware
+            (wrap-predicates :host-pred safe-host?)
+            "http://192.168.1.1")))))
+
+(defn safe-port?
+  [port]
+  (#{80 443} port))
+
+(deftest port-pred-test
+  (testing "port-pred test"
+    (is (= successful-results
+           (get-with-middleware
+            (wrap-predicates :port-pred safe-port?)
+            "http://www.google.com")))
+    (is (= successful-results
+           (get-with-middleware
+            (wrap-predicates :port-pred safe-port?)
+            "https://www.google.com")))
+    (is (= successful-results
+           (get-with-middleware
+            (wrap-predicates :port-pred safe-port?)
+            "http://www.google.com:80")))
+    (is (= successful-results
+           (get-with-middleware
+            (wrap-predicates :port-pred safe-port?)
+            "https://www.google.com:443")))
+    (is (= default-results
+           (get-with-middleware
+            (wrap-predicates :port-pred safe-port?)
+            "http://localhost:3000")))))
+
 (deftest custom-status-code-test
   (testing "Test with custom status code"
     (is (= {:status 404, :headers {}, :body ""}
            (get-with-middleware (wrap-validators :status 404 :regexes [#"google"])
-                                "http://google.com")))))
+                                "http://google.com")))
+    (is (= {:status 404, :headers {"Server" "nginx"}, :body "Not found"}
+           (get-with-middleware (wrap-predicates :status 404
+                                                 :headers {"Server" "nginx"}
+                                                 :body "Not found"
+                                                 :port-pred safe-port?)
+                                "http://localhost:9000")))))


### PR DESCRIPTION
Allows user to use predicates as part of middleware

I left your `wrap-validators` function as is for backward compatibility.