### PR TITLE
Bugfix to respect :ignore-unknown-host

### DIFF
--- a/src/clj_http_ssrf/core.clj
+++ b/src/clj_http_ssrf/core.clj
@@ -1,8 +1,9 @@
 (ns clj-http-ssrf.core
   (:require [clj-http.client :as client]
-            [inet.data.ip :as ip])
-  (:import [java.net InetAddress]))
-
+            [clj-http.util :refer [opt]]
+            [inet.data.ip :as ip]
+            [clojure.stacktrace :refer [root-cause]])
+  (:import (java.net InetAddress UnknownHostException)))
 
 (defn- make-response
   [status headers body]
@@ -10,6 +11,25 @@
    :headers headers
    :body body})
 
+(defn- get-host-address
+  ;; Passing in parsed-url since it was already computed
+  [req parsed-url]
+  (let [server-name (:server-name parsed-url)]
+    (try
+      (.getHostAddress (InetAddress/getByName server-name))
+      (catch Exception e
+        (if (or (not= (type (root-cause e)) UnknownHostException)
+                (not (opt req :ignore-unknown-host)))
+          (throw (root-cause e)))))))
+
+(defn- parse-url
+  [req]
+  (let [url        (:url req)
+        parsed-url (client/parse-url url)]
+    {:url url
+     :scheme (:scheme parsed-url)
+     :port (:server-port parsed-url)
+     :host (get-host-address req parsed-url)}))
 
 (defn wrap-validators
   "
@@ -19,17 +39,13 @@
   [& {:keys [regexes ports hosts status headers body] :or {status 403 headers {} body ""}}]
   (fn [client]
     (fn [req]
-      (let [url          (:url req)
-            parsed-url   (client/parse-url url)
-            parsed-port  (:server-port parsed-url)
-            server-name  (:server-name parsed-url)
-            host-address (.getHostAddress (InetAddress/getByName server-name))]
+      (let [{:keys [url host port]} (parse-url req)]
         (cond
           (and regexes (some #(re-find %1 url) regexes))
           (make-response status headers body)
-          (and ports (some #{parsed-port} ports))
+          (and ports (some #{port} ports))
           (make-response status headers body)
-          (and hosts (some #(ip/network-contains? %1 host-address) hosts))
+          (and hosts (some #(ip/network-contains? %1 host) hosts))
           (make-response status headers body)
           :else (client req))))))
 
@@ -49,12 +65,7 @@
       :or {status 403 headers {} body ""}}]
   (fn [client]
     (fn [req]
-      (let [url         (:url req)
-            parsed-url  (client/parse-url url)
-            scheme      (:scheme parsed-url)
-            port        (:server-port parsed-url)
-            server-name (:server-name parsed-url)
-            host        (.getHostAddress (InetAddress/getByName server-name))]
+      (let [{:keys [scheme url host port]} (parse-url req)]
         (cond
           (and scheme-pred (not (scheme-pred scheme)))
           (make-response status headers body)

--- a/src/clj_http_ssrf/core.clj
+++ b/src/clj_http_ssrf/core.clj
@@ -3,13 +3,13 @@
             [clj-http.util :refer [opt]]
             [inet.data.ip :as ip]
             [clojure.stacktrace :refer [root-cause]])
-  (:import (java.net InetAddress UnknownHostException)))
+  (:import [java.net InetAddress UnknownHostException]))
 
 (defn- make-response
   [status headers body]
-  {:status status
+  {:status  status
    :headers headers
-   :body body})
+   :body    body})
 
 (defn- get-host-address
   ;; Passing in parsed-url since it was already computed
@@ -26,10 +26,10 @@
   [req]
   (let [url        (:url req)
         parsed-url (client/parse-url url)]
-    {:url url
+    {:url    url
      :scheme (:scheme parsed-url)
-     :port (:server-port parsed-url)
-     :host (get-host-address req parsed-url)}))
+     :port   (:server-port parsed-url)
+     :host   (get-host-address req parsed-url)}))
 
 (defn wrap-validators
   "

--- a/src/clj_http_ssrf/reserved.clj
+++ b/src/clj_http_ssrf/reserved.clj
@@ -2,20 +2,20 @@
   "Information from https://www.wikiwand.com/en/Reserved_IP_addresses")
 
 (def reserved-ip-data
-  {:software {:broadcast-this "0.0.0.0/8"}
-   :private {:local-a "10.0.0.0/8"
-             :local-b "172.16.0.0/12"
-             :local-c "192.168.0.0/16"
-             :inter-network "198.18.0.0/15"
-             :service-provider-subscribers "100.64.0.0/10"
-             :iana-special-purpose "192.0.0.0/24"}
-   :documentation {:test-net-1 "192.0.2.0/24"
-                   :test-net-2 "198.51.100.0/24"
-                   :test-net-3 "203.0.113.0/24"}
-   :internet {:multicast "224.0.0.0/4"
-              :future "240.0.0.0/4"}
-   :host {:loopback "127.0.0.0/8"}
-   :subnet {:link-local "169.254.0.0/16"}})
+  {:software      {:broadcast-this               "0.0.0.0/8"}
+   :private       {:local-a                      "10.0.0.0/8"
+                   :local-b                      "172.16.0.0/12"
+                   :local-c                      "192.168.0.0/16"
+                   :inter-network                "198.18.0.0/15"
+                   :service-provider-subscribers "100.64.0.0/10"
+                   :iana-special-purpose         "192.0.0.0/24"}
+   :documentation {:test-net-1                   "192.0.2.0/24"
+                   :test-net-2                   "198.51.100.0/24"
+                   :test-net-3                   "203.0.113.0/24"}
+   :internet      {:multicast                    "224.0.0.0/4"
+                   :future                       "240.0.0.0/4"}
+   :host          {:loopback                     "127.0.0.0/8"}
+   :subnet        {:link-local                   "169.254.0.0/16"}})
 
 (defn- get-all-vals
   [m]

--- a/test/clj_http_ssrf/core_test.clj
+++ b/test/clj_http_ssrf/core_test.clj
@@ -3,7 +3,8 @@
             [clj-http.client :as client]
             [clj-http-ssrf.core :refer :all]
             [clj-http-ssrf.reserved :as r]
-            [inet.data.ip :as ip]))
+            [inet.data.ip :as ip])
+  (:import [java.net UnknownHostException]))
 
 (def successful-results
   {:status 999 :headers {"Successful" "true"} :body "Success"})
@@ -147,17 +148,16 @@
 (deftest get-host-address-test
   (testing "get-host-address to make sure it respects :ignore-unknown-host"
     (is (thrown-with-msg?
-         java.net.UnknownHostException
-         #"example.invalid: nodename nor servname provided, or not known"
+         UnknownHostException
+         #"example.invalid"
          (get-with-middleware (wrap-validators :status 404 :regexes [#"google"])
                               "http://example.invalid")))
     (is (= successful-results
            (get-with-middleware (wrap-validators :status 404 :regexes [#"google"])
                                 "http://example.invalid"
                                 {:ignore-unknown-host true})))
-    ;; This test fails sometimes? Not sure why
     (is (thrown-with-msg?
-         java.net.UnknownHostException
+         UnknownHostException
          #"example.invalid"
          (get-with-middleware (wrap-predicates :status 404
                                                :headers {"Server" "nginx"}


### PR DESCRIPTION
Hey, I realized that `clj-http-ssrf` doesn't respect `:ignore-unknown-host` and so I added some code to try and ignore that. I'm not sure if this is the "correct" way to fix it, since another option is to just re-order the middleware.

What do you think?

Also, I hit a strange problem that you might be able to help with. I have a test case that fails _sometimes_. It's prefixed with

```
    ;; This test fails sometimes? Not sure why
```

Would you happen to know why?